### PR TITLE
next game button

### DIFF
--- a/assets/javascript/game.js
+++ b/assets/javascript/game.js
@@ -77,6 +77,12 @@ window.Game = React.createClass({
               (g) => { this.setState({game: g}); });
     },
 
+    nextGame: function(e) {
+        e.preventDefault();
+        $.post('/next-game', JSON.stringify({game_id: this.state.game.id}),
+              (g) => { this.setState({game: g}); });
+    },
+
     render: function() {
         if (!this.state.game) {
             return (<p className="loading">Loading&hellip;</p>);
@@ -133,6 +139,7 @@ window.Game = React.createClass({
                 <form id="mode-toggle" className={this.state.codemaster ? "codemaster-selected" : "player-selected"}>
                     <button onClick={(e) => this.toggleRole(e, 'player')} className="player">Player</button>
                     <button onClick={(e) => this.toggleRole(e, 'codemaster')} className="codemaster">Spymaster</button>
+                    <button onClick={(e) => this.nextGame(e)} id="next-game-btn">Next game</button>
                 </form>
             </div>
         );

--- a/assets/javascript/lobby.js
+++ b/assets/javascript/lobby.js
@@ -8,7 +8,6 @@ window.Lobby = React.createClass({
         return {
             newGameName: this.props.defaultGameID,
             selectedGame: null,
-            games: [],
         };
     },
 

--- a/assets/stylesheets/game.css
+++ b/assets/stylesheets/game.css
@@ -79,6 +79,10 @@
     color: #999;
 }
 
+#next-game-btn {
+    margin-left: 10px;
+}
+
 .cell {
     width: 120px;
     height: 80px;


### PR DESCRIPTION
A common use case is to play multiple codenames games in a row (BECAUSE IT'S SO FUN). Currently the flow to do this is to go back to the homepage, make the new game, then verbally tell your friend to hit refresh on the home page (or as of your latest update, tell them the new key). Having a single button to do it reduces some friction there.

Karl mentions this also brings up an opportunity in the future to eliminate words showing up in consecutive games. Like, when playing real life codenames, transitioning to the next game actually guarantees that you will not see the same cards (because you flip the cards over, or you put them back in the box). Having a new game button allows us in a future iteration to move toward that world where we can keep state of which words have already been in play in a session.

I currently have this button next to the "Player/Spymaster" button. You can choose where you want it to go, but I actually argue that we should get rid of the "End turn button" completely since it is essentially useless when playing in person, move the "Player/Spymaster" button up above the game, and have "Next Game" be the only button below the game. I think the decision to remove the "End turn button" depends on how much you want horsepaste.com to cater toward only playing in person, or if you also want it to support online play.
