### PR TITLE
title link

### DIFF
--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -25,7 +25,9 @@ window.App = React.createClass({
         return (
             <div id="application">
                 <div id="topbar">
-                    <h1>Codenames</h1>
+                    <a href={"http://" + window.location.host}>
+                        <h1>Codenames</h1>
+                    </a>
                 </div>
                 {pane}
             </div>

--- a/frontend.go
+++ b/frontend.go
@@ -43,6 +43,11 @@ const tpl = `
 			  margin-bottom: 1em;
 			}
 
+			#topbar a {
+			  color: black;
+			  text-decoration: none;
+			}
+
 			h1 {
 			  text-transform: uppercase;
 			  letter-spacing: 0.2em;
@@ -64,11 +69,6 @@ const tpl = `
     </head>
     <body>
 		<div id="app">
-			<div id="application">
-				<div id="topbar">
-					<h1>Codenames</h1>
-				</div>
-			</div>
 		</div>
         <script type="text/babel">
             ReactDOM.render(<window.App />, document.getElementById('app'));


### PR DESCRIPTION
Seems to be a good UI change and I can't think of a reason to not link to home. Product-wise even if we're going to encourage synced machines to stay on the same game id, it's still nice to provide a link back in case they need it for w/e reason.

A specific use-case that happened at Twitch on Friday was we decided to split our huge Codenames group into 2 separate groups. So a guy took his laptop and tried to back out to the home page and raged when he couldn't click on the title.
