### PR TITLE
Confirm new game request when current game hasn't ended.

### DIFF
--- a/frontend/ui/game.tsx
+++ b/frontend/ui/game.tsx
@@ -130,6 +130,14 @@ export class Game extends React.Component {
 
   public nextGame(e) {
     e.preventDefault();
+    // Ask for confirmation when current game hasn't finished
+    let allowNextGame = (
+      this.state.game.winning_team ||
+      confirm("Do you really want to start a new game?")
+    );
+    if (!allowNextGame) {
+      return;
+    }
     $.post(
       '/next-game',
       JSON.stringify({


### PR DESCRIPTION
While playing we had people click mistakenly click the new game button; so we added a quick and dirty `OK` `Cancel` confirmation when the game hasn't finished yet.