### PR TITLE
Don't reset game when joining from lobby.

### DIFF
--- a/frontend/ui/game.tsx
+++ b/frontend/ui/game.tsx
@@ -143,6 +143,7 @@ export class Game extends React.Component {
       JSON.stringify({
         game_id: this.state.game.id,
         word_set: this.state.game.word_set,
+        create_new: true,
       }),
       g => {
         this.setState({ game: g, codemaster: false });

--- a/frontend/ui/lobby.tsx
+++ b/frontend/ui/lobby.tsx
@@ -23,6 +23,7 @@ export const Lobby = ({ defaultGameID }) => {
       JSON.stringify({
         game_id: newGameName,
         word_set: words[selectedLanguage].split(', '),
+        create_new: false,
       }),
       g => {
         const newURL = (document.location.pathname = '/' + newGameName);

--- a/server.go
+++ b/server.go
@@ -155,6 +155,7 @@ func (s *Server) handleNextGame(rw http.ResponseWriter, req *http.Request) {
 	var request struct {
 		GameID  string   `json:"game_id"`
 		WordSet []string `json:"word_set"`
+		CreateNew bool   `json:"create_new"`
 	}
 
 	if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
@@ -182,8 +183,11 @@ func (s *Server) handleNextGame(rw http.ResponseWriter, req *http.Request) {
 		sort.Strings(words)
 	}
 
-	g := newGame(request.GameID, randomState(words))
-	s.games[request.GameID] = g
+	g, ok := s.games[request.GameID]
+	if (!ok || request.CreateNew) {
+		g := newGame(request.GameID, randomState(words))
+		s.games[request.GameID] = g
+	}
 	writeGame(rw, g)
 }
 

--- a/server.go
+++ b/server.go
@@ -153,9 +153,9 @@ func (s *Server) handleEndTurn(rw http.ResponseWriter, req *http.Request) {
 
 func (s *Server) handleNextGame(rw http.ResponseWriter, req *http.Request) {
 	var request struct {
-		GameID  string   `json:"game_id"`
-		WordSet []string `json:"word_set"`
-		CreateNew bool   `json:"create_new"`
+		GameID    string   `json:"game_id"`
+		WordSet   []string `json:"word_set"`
+		CreateNew bool     `json:"create_new"`
 	}
 
 	if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
@@ -185,7 +185,7 @@ func (s *Server) handleNextGame(rw http.ResponseWriter, req *http.Request) {
 
 	g, ok := s.games[request.GameID]
 	if (!ok || request.CreateNew) {
-		g := newGame(request.GameID, randomState(words))
+		g = newGame(request.GameID, randomState(words))
 		s.games[request.GameID] = g
 	}
 	writeGame(rw, g)


### PR DESCRIPTION
When a game is active with, say "potato" as its ID and a new player joins from
the lobby by writing "potato", this resets the ongoing game.

I have added a `create_new` boolean to the corresponding request and set it
differently when it's used from the lobby (`create_new: false`) and when it's
used from the board (`create_new: true`).