### PR TITLE
Build backend code in Docker instead of getting it from GitHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,19 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y nodejs && \
     apt-get clean && \
     npm install -g parcel-bundler
-    
+
 # Copy project into docker instance
 COPY . /app
 WORKDIR /app
+RUN mkdir -p /go/src/codenames
+RUN cp *.go /go/src/codenames/
 
-# Get the go app
-RUN go get -u github.com/jbowens/codenames
+# Get dependencies
+RUN go get
 
 # Build backend and frontend 
-RUN go build cmd/codenames/main.go && \
+RUN go build /go/src/codenames && \
+    go build /app/cmd/codenames/main.go && \
     cd /app/frontend/ && \
     npm install && \
     sh build.sh

--- a/cmd/codenames/main.go
+++ b/cmd/codenames/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/jbowens/codenames"
+	"codenames"
 )
 
 func main() {


### PR DESCRIPTION
Hi, this is a great app, thanks very much for building it!

I noticed when trying to build the backend code using Docker, it was taking a copy from GitHub instead of the code I'd modified (another PR incoming). I thought that was kind of odd, so I tried to fix it. This still gets your 'dictionary' repo from GitHub, but builds the Go code from the local project.

It seems to be doing what I need now. What do you think?