### PR TITLE
Limit number of active Spymasters to 2

### DIFF
--- a/frontend/ui/game.tsx
+++ b/frontend/ui/game.tsx
@@ -71,7 +71,22 @@ export class Game extends React.Component {
 
   public toggleRole(e, role) {
     e.preventDefault();
-    this.setState({ codemaster: role == 'codemaster' });
+    const newRoleCodemaster = role == 'codemaster';
+    if (this.state.codemaster != newRoleCodemaster) {
+      $.post(
+        '/claim-spymaster',
+        JSON.stringify({
+          game_id: this.state.game.id,
+          state_id: this.state.game.state_id,
+          spymaster: newRoleCodemaster
+        }),
+        g => {
+          this.setState({ codemaster: newRoleCodemaster });
+        }
+      ).fail(function () {
+        alert('There are already two spymasters registered');
+      });
+    }
   }
 
   public guess(e, idx, word) {

--- a/game.go
+++ b/game.go
@@ -61,10 +61,11 @@ func (t Team) Repeat(n int) []Team {
 // a Game's state. It's used to recreate games after
 // a process restart.
 type GameState struct {
-	Seed     int64    `json:"seed"`
-	Round    int      `json:"round"`
-	Revealed []bool   `json:"revealed"`
-	WordSet  []string `json:"word_set"`
+	Seed           int64    `json:"seed"`
+	SpymasterCount int      `json:"spymaster_count"`
+	Round          int      `json:"round"`
+	Revealed       []bool   `json:"revealed"`
+	WordSet        []string `json:"word_set"`
 }
 
 func (gs GameState) ID() string {
@@ -97,9 +98,10 @@ func decodeGameState(s string, defaultWords []string) (GameState, bool) {
 
 func randomState(words []string) GameState {
 	return GameState{
-		Seed:     rand.Int63(),
-		Revealed: make([]bool, wordsPerGame),
-		WordSet:  words,
+		Seed:           rand.Int63(),
+		SpymasterCount: 0,
+		Revealed:       make([]bool, wordsPerGame),
+		WordSet:        words,
 	}
 }
 


### PR DESCRIPTION
Hi again!

Now that we're all self-isolating, I thought it would be a great idea to play a game of Remote Codenames using this app, with the help of Skype/Zoom. We haven't tried it yet, but I think it should be possible.

The problem is that anyone is able to become the Spymaster at any time. The temptation to peek at the answers is too great.

Here I'm limiting the number of Spymasters to 2. Whenever the Spymaster button is pressed, a request is made to the server, which keeps a record of how many clients have pressed the Spymaster button. If there are already 2 Spymasters, the third requester will not be able to take up the role.

Having never written any Go code before, I copied the pattern that you've written for other functions. It seems to work but I don't know if there are any edge cases that you might be more aware of?