### PR TITLE
favicon turn indicator

### DIFF
--- a/frontend.go
+++ b/frontend.go
@@ -17,7 +17,7 @@ const tpl = `
         <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
         <link rel="stylesheet" type="text/css" href="/static/game.css" />
         <link rel="stylesheet" type="text/css" href="/static/lobby.css" />
-        <link rel="shortcut icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAwSURBVHgB7dJRDQAABEVRJFJBNvX8SEQINrO9G+B8XTaPokFCwwAsAPdxqmKk90ADdlUE2gRVHXcAAAAASUVORK5CYII="/>
+        <link rel="shortcut icon" type="image/png" id="favicon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAA8SURBVHgB7dHBDQAgCAPA1oVkBWdzPR84kW4AD0LCg36bXJqUcLL2eVY/EEwDFQBeEfPnqUpkLmigAvABK38Grs5TfaMAAAAASUVORK5CYII="/>
 
         <script type="text/javascript">
              {{if .SelectedGameID}}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "cssnano": "^4.1.10",
     "parcel-bundler": "^1.12.3",
-    "typescript": "^3.4.5"
+    "typescript": "^3.8.3"
   },
   "name": "frontend",
   "version": "1.0.0",

--- a/frontend/ui/game.tsx
+++ b/frontend/ui/game.tsx
@@ -6,6 +6,9 @@ import { Settings, SettingsButton, SettingsPanel } from '~/ui/settings';
 let jquery = require('jquery');
 window.$ = window.jQuery = jquery;
 
+const defaultFavicon = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAA8SURBVHgB7dHBDQAgCAPA1oVkBWdzPR84kW4AD0LCg36bXJqUcLL2eVY/EEwDFQBeEfPnqUpkLmigAvABK38Grs5TfaMAAAAASUVORK5CYII=';
+const blueTurnFavicon = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAmSURBVHgB7cxBAQAABATBo5ls6ulEiPt47ASYqJ6VIWUiICD4Ehyi7wKv/xtOewAAAABJRU5ErkJggg==';
+const redTurnFavicon = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAmSURBVHgB7cwxAQAACMOwgaL5d4EiELGHoxGQGnsVaIUICAi+BAci2gJQFUhklQAAAABJRU5ErkJggg==';
 export class Game extends React.Component {
   constructor(props) {
     super(props);
@@ -38,14 +41,45 @@ export class Game extends React.Component {
     }
   }
 
-  public componentWillMount() {
+  public componentDidMount(prevProps, prevState) {
     window.addEventListener('keydown', this.handleKeyDown.bind(this));
+    this.setDarkMode(prevProps, prevState);
+    this.setTurnIndicatorFavicon(prevProps, prevState);
     this.refresh();
   }
 
   public componentWillUnmount() {
     window.removeEventListener('keydown', this.handleKeyDown.bind(this));
+    document.getElementById("favicon").setAttribute("href", defaultFavicon);
     this.setState({ mounted: false });
+  }
+
+  public componentDidUpdate(prevProps, prevState) {
+    this.setDarkMode(prevProps, prevState);
+    this.setTurnIndicatorFavicon(prevProps, prevState);
+  }
+
+  private setDarkMode(prevProps, prevState) {
+    if (!prevState?.settings.darkMode && this.state.settings.darkMode) {
+      document.body.classList.add('dark-mode');
+    }
+    if (prevState?.settings.darkMode && !this.state.settings.darkMode) {
+      document.body.classList.remove('dark-mode');
+    }
+  }
+
+  private setTurnIndicatorFavicon(prevProps, prevState) {
+    if (
+      prevState?.game?.winning_team !== this.state.game?.winning_team ||
+      prevState?.game?.round !== this.state.game?.round ||
+      prevState?.game?.state_id !== this.state.game?.state_id
+    ) {
+      if (this.state.game?.winning_team) {
+        document.getElementById("favicon").setAttribute("href", defaultFavicon);
+      } else {
+        document.getElementById("favicon").setAttribute("href", this.currentTeam() === 'blue' ? blueTurnFavicon : redTurnFavicon);
+      }
+    }
   }
 
   public refresh() {
@@ -190,13 +224,6 @@ export class Game extends React.Component {
           values={this.state.settings}
         />
       );
-    }
-
-    // TODO: This is hacky as hell.
-    if (this.state.settings.darkMode) {
-      document.body.classList.add('dark-mode');
-    } else {
-      document.body.classList.remove('dark-mode');
     }
 
     let status, statusClass;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/912050/78512502-ecfcb300-7759-11ea-982f-1df45a124f83.png)

When it's blue's turn it will show blue favicon. When it's red's turn it will show red favicon. In main menu, or when a game has been won, it will show the default favicon.

In this PR I perform the favicon updates from `componentDidMount` and `componentDidUpdate`, and also move the dark mode settings into here since it's doing something very similar. This is how React expects these things to be done pre-hooks. If we ever use React hooks later, we get the `useEffect` hook https://reactjs.org/docs/hooks-effect.html

I bump Typescript version so I can use optional chaining https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining 

(up to you whether you wanna actually change the default favicon. we could go with the same default favicon)

![website](https://user-images.githubusercontent.com/912050/78512231-9b532900-7757-11ea-8402-aebe91d52a5b.gif)
