### PR TITLE
resolve pending game state request on new game start

### DIFF
--- a/server.go
+++ b/server.go
@@ -258,7 +258,10 @@ func (s *Server) handleNextGame(rw http.ResponseWriter, req *http.Request) {
 			gh = newHandle(newGame(request.GameID, randomState(words)), s.Store)
 			s.games[request.GameID] = gh
 		} else if request.CreateNew {
-			nextState := nextGameState(gh.g.GameState)
+			var nextState GameState
+			gh.update(func(g *Game) {
+				nextState = nextGameState(g.GameState)
+			})
 			gh = newHandle(newGame(request.GameID, nextState), s.Store)
 			s.games[request.GameID] = gh
 		}


### PR DESCRIPTION
There's a small bug in the game at the moment where the pending game state request that is timed out for 15 seconds is not being resolved when a new game is started. That leads to some strange behaviour right after a new game is started.