### PR TITLE
disabled guessing when in codemaster role

### DIFF
--- a/frontend/game.css
+++ b/frontend/game.css
@@ -109,6 +109,10 @@
   height: 18%;
 }
 
+.cell.disabled {
+  cursor: not-allowed !important;
+}
+
 .board {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/ui/game.tsx
+++ b/frontend/ui/game.tsx
@@ -118,8 +118,11 @@ export class Game extends React.Component {
     this.setState({ codemaster: role == 'codemaster' });
   }
 
-  public guess(e, idx, word) {
+  public guess(e, idx) {
     e.preventDefault();
+    if (this.state.codemaster) {
+      return; // ignore if player is the codemaster
+    }
     if (this.state.game.revealed[idx]) {
       return; // ignore if already revealed
     }
@@ -295,6 +298,7 @@ export class Game extends React.Component {
                 'cell ' +
                 this.state.game.layout[idx] +
                 ' ' +
+                (this.state.codemaster ? 'disabled ' : '') +
                 (this.state.game.revealed[idx] ? 'revealed' : 'hidden-word')
               }
               onClick={e => this.guess(e, idx, w)}


### PR DESCRIPTION
At the moment one can make guesses as the codemaster. While that's very convenient in development 😅, I don't see a scenario when you'd ever want that to happen otherwise. And since it can happen accidentally, it makes sense to disable it, doesn't it?