### PR TITLE
Idea: hide the revealed words

### DIFF
--- a/frontend/game.css
+++ b/frontend/game.css
@@ -137,6 +137,10 @@
 }
 .board .neutral.revealed {
   background: #ede2cc;
+  color:#eed;
+}
+.board .neutral.revealed:hover, .board .neutral.revealed:active {
+  color:#000;
 }
 
 .cell .word {
@@ -163,11 +167,15 @@
 
 .board .red.revealed {
   background: #d13030;
-  color: #fff;
+  color: #e33;
 }
 .board .blue.revealed {
   background: #4183cc;
-  color: #fff;
+  color: #48e;
+}
+.board .red.revealed:hover, .board .red.revealed:active,
+.board .blue.revealed:hover, .board .blue.revealed:active {
+  color:#fff;
 }
 .board .black.revealed {
   background: #000000;


### PR DESCRIPTION
Thank you for a very nice implementation! 

One idea, if you want to try it out: In the tabletop game it makes the game play faster, when all the chosen cards are covered up - so you can only see the few remaining cards.


--
Color: nearly invisible revealed words
Simulate that in the game the agent cards cover up the chosen words. Only the remaining words stay visible. (Click or hover to show them.)