### PR TITLE
Fix codemaster dark mode colours when game ends

### DIFF
--- a/frontend/game.css
+++ b/frontend/game.css
@@ -182,6 +182,9 @@
 .player .board.win > .cell.black.hidden-word {
   background: rgba(153, 153, 153, 0.4);
 }
+.dark-mode  .codemaster .board.win > .cell.neutral{
+  color: #aaa;
+}
 
 #remaining span {
   display: inline-block;

--- a/frontend/lobby.css
+++ b/frontend/lobby.css
@@ -13,6 +13,10 @@ body {
   text-decoration: none;
 }
 
+.dark-mode #topbar a{
+  color: #888;
+}
+
 h1 {
   text-transform: uppercase;
   letter-spacing: 0.2em;


### PR DESCRIPTION
Issues:

![2020-04-22-092510_749x796_scrot](https://user-images.githubusercontent.com/16846521/79872128-b5179000-8428-11ea-9652-895062cbdec8.png)

* CODENAMES in header is black
* Neutral words (distinguished by turning on colour blind mode as well as dark mode) inherit from the winning teams colour (red)

---

Fixes:

![2020-04-22-093125_725x771_scrot](https://user-images.githubusercontent.com/16846521/79872044-9e713900-8428-11ea-9102-de6fdd8514e9.png)

* CODENAMES is `#888` to match other text colours in dark mode
* Neutral words are now coloured `#aaa` for codemaster when the game is over
* Normal colour mode is unchanged

PS: Thanks for making this! Lots of fun during lockdown.