### PR TITLE
server: record a games completed stat

### DIFF
--- a/cmd/codenames/main.go
+++ b/cmd/codenames/main.go
@@ -33,7 +33,12 @@ func main() {
 	}
 	log.Printf("[STARTUP] Opening pebble db from directory: %s\n", dir)
 
-	db, err := pebble.Open(dir, nil)
+	db, err := pebble.Open(dir, &pebble.Options{
+		Merger: &pebble.Merger{
+			Merge: codenames.PebbleMerge,
+			Name:  "codenameskv",
+		},
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "pebble.Open: %s\n", err)
 		os.Exit(1)

--- a/store.go
+++ b/store.go
@@ -1,6 +1,8 @@
 package codenames
 
 import (
+	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -62,6 +64,79 @@ func (ps *PebbleStore) Save(g *Game) error {
 	return err
 }
 
+func (ps *PebbleStore) CounterAdd(stat string, v int64) error {
+	var b [binary.MaxVarintLen64]byte
+	n := binary.PutVarint(b[:], v)
+
+	k := fmt.Sprintf("/stats/counters/%s", stat)
+	return ps.DB.Merge([]byte(k), b[:n], nil)
+}
+
+func (ps *PebbleStore) GetCounter(statPrefix string) (int64, error) {
+	prefix := []byte(fmt.Sprintf("/stats/counters/%s", statPrefix))
+
+	iter := ps.DB.NewIter(nil)
+	iter.SeekGE(prefix)
+
+	var sum int64
+	for ; iter.Valid() && bytes.HasPrefix(iter.Key(), prefix); iter.Next() {
+		rawV := iter.Value()
+		v, n := binary.Varint(rawV)
+		if n < 0 {
+			return 0, fmt.Errorf("unable to read stat value: %v for key %q", rawV, iter.Key())
+		}
+		sum += v
+	}
+	err := iter.Error()
+	if closeErr := iter.Close(); closeErr != nil {
+		err = closeErr
+	}
+
+	return sum, err
+}
+
+// PebbleMerge implements the pebble.Merge function type.
+func PebbleMerge(k, v []byte) (pebble.ValueMerger, error) {
+	vInt, n := binary.Varint(v)
+	if n < 0 {
+		return nil, fmt.Errorf("unable to read merge value: %v", v)
+	}
+	//if bytes.HasPrefix(k, []byte("/stats/counters/")) {
+	return &addValueMerger{v: vInt}, nil
+	//}
+	//return nil, fmt.Errorf("unrecognized merge key: %s", pretty.Sprint(k))
+}
+
+// addValueMerger implements pebble.ValueMerger by interpreting values as a
+// signed varint and adding its operands.
+type addValueMerger struct {
+	v int64
+}
+
+func (m *addValueMerger) MergeNewer(value []byte) error {
+	v, n := binary.Varint(value)
+	if n < 0 {
+		return fmt.Errorf("unable to read merge value: %v", value)
+	}
+	m.v = m.v + v
+	return nil
+}
+
+func (m *addValueMerger) MergeOlder(value []byte) error {
+	v, n := binary.Varint(value)
+	if n < 0 {
+		return fmt.Errorf("unable to read merge value: %v", value)
+	}
+	m.v = m.v + v
+	return nil
+}
+
+func (m *addValueMerger) Finish() ([]byte, error) {
+	b := make([]byte, binary.MaxVarintLen64)
+	n := binary.PutVarint(b, m.v)
+	return b[:n], nil
+}
+
 func gameKV(g *Game) (key, value []byte, err error) {
 	value, err = json.Marshal(g)
 	if err != nil {
@@ -80,4 +155,6 @@ func mkkey(unixSecs int64, id string) []byte {
 
 type discardStore struct{}
 
-func (ds discardStore) Save(*Game) error { return nil }
+func (_ discardStore) Save(*Game) error                 { return nil }
+func (_ discardStore) GetCounter(string) (int64, error) { return 0, nil }
+func (_ discardStore) CounterAdd(string, int64) error   { return nil }


### PR DESCRIPTION
Record a game completed statistic and persist it across process restarts
by storing it in the local kv store.