### PR TITLE
use multi-stage build to reduce size of built image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-stretch
+FROM golang:1.12-stretch as builder
 
 # Install npm and parcel
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
@@ -15,11 +15,20 @@ RUN cp *.go /go/src/codenames/
 # Get dependencies
 RUN go get
 
-# Build backend and frontend 
+# Build backend and frontend
 RUN go build /app/cmd/codenames/main.go && \
     cd /app/frontend/ && \
     npm install && \
     sh build.sh
+
+# Copy build artifacts from previous build stage (to remove files not necessary for
+# deployment.)
+FROM debian:buster-slim
+
+WORKDIR /app
+COPY --from=builder /app/main .
+COPY --from=builder /app/assets ./assets
+COPY --from=builder /app/frontend/dist ./frontend/dist
 
 # Expose 9091 port
 EXPOSE 9091/tcp


### PR DESCRIPTION
This PR uses Docker multi-stage builds to reduce the uncompressed Docker image size to 87.4 MB from 1.36 GB. These savings are accomplished by removing unnecessary files, npm and go packages, the go compiler, and others.

See https://docs.docker.com/develop/develop-images/multistage-build/ for more information on Docker multistage builds.