### PR TITLE
Add screen reader accessibility

### DIFF
--- a/frontend/ui/custom_words.tsx
+++ b/frontend/ui/custom_words.tsx
@@ -37,7 +37,7 @@ const CustomWords = ({
       </div>
     {expanded && (
       <div>
-        <textarea value={words} onChange={(e) => onWordChange(e.target.value)} />
+        <textarea value={words} aria-label="custom word set" onChange={(e) => onWordChange(e.target.value)} />
       </div>
     )}
   </div>

--- a/frontend/ui/lobby.tsx
+++ b/frontend/ui/lobby.tsx
@@ -88,6 +88,7 @@ export const Lobby = ({ defaultGameID }) => {
           <input
             type="text"
             id="game-name"
+            aria-label="game identifier"
             autoFocus
             onChange={(e) => {
               setNewGameName(e.target.value);

--- a/frontend/ui/settings.tsx
+++ b/frontend/ui/settings.tsx
@@ -52,7 +52,7 @@ export class SettingsButton extends React.Component {
 
   public render() {
     return (
-      <button onClick={e => this.handleClick(e)} className="gear">
+      <button onClick={e => this.handleClick(e)} className="gear" aria-label="settings">
         <svg
           width="30"
           height="30"
@@ -77,7 +77,10 @@ export class SettingsPanel extends React.Component {
   public render() {
     return (
       <div className="settings">
-        <div onClick={e => this.props.toggleView(e)} className="close-settings">
+        <div 
+          onClick={e => this.props.toggleView(e)}
+          className="close-settings"
+        >
           <svg
             width="32"
             height="32"
@@ -90,6 +93,8 @@ export class SettingsPanel extends React.Component {
               transform="translate(1 1)"
               stroke="black"
               strokeWidth="2"
+              role="button"
+              aria-label="close settings"
             />
           </svg>
         </div>

--- a/frontend/ui/timer.tsx
+++ b/frontend/ui/timer.tsx
@@ -51,7 +51,16 @@ const Timer: React.FunctionComponent<TimerProps> = ({
   if (timeRemaining.total <= 30) color = '#F70';
   if (timeRemaining.total <= 10) color = '#E22';
   return (
-    <span style={{ color }}>
+    <span 
+      style={{ color }}
+      role="img"
+      aria-label={
+        "Time remaining: " +
+        timeRemaining.minutes.toString() +
+        ":" +
+        timeRemaining.seconds.toString()
+      }
+    >
       {timeRemaining.minutes}:{timeRemaining.seconds}
     </span>
   );

--- a/frontend/ui/timer_settings.tsx
+++ b/frontend/ui/timer_settings.tsx
@@ -61,6 +61,7 @@ const TimerSettings: React.FunctionalComponent<TimerSettingsProps> = ({
           <div>
             <span>Enforce timer:</span>
             <Toggle
+              name='Enforce Timer'
               state={enforceTimerEnabled}
               handleToggle={() => setEnforceTimerEnabled(!enforceTimerEnabled)}
             />

--- a/frontend/ui/toggle-set.tsx
+++ b/frontend/ui/toggle-set.tsx
@@ -28,6 +28,7 @@ const ToggleSet: React.FunctionalComponent<ToggleSetProps> = ({
         </div>
       </div>
       <Toggle
+        name={toggle.name}
         state={values[toggle.setting]}
         handleToggle={(e) => handleToggle(e, toggle.setting)}
       />

--- a/frontend/ui/toggle.tsx
+++ b/frontend/ui/toggle.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 
 interface ToggleProps {
+  name: string;
   state: boolean;
   handleToggle: any;
 }
 
 const Toggle: React.FunctionalComponent<ToggleProps> = ({
+  name,
   state,
   handleToggle,
 }) => {
@@ -14,7 +16,12 @@ const Toggle: React.FunctionalComponent<ToggleProps> = ({
       onClick={handleToggle}
       className={state ? 'toggle active' : 'toggle inactive'}
     >
-      <div className="switch"></div>
+      <div 
+        className="switch"
+        role="button"
+        aria-label={name}
+        aria-pressed={!!state}
+      ></div>
     </div>
   );
 };

--- a/frontend/ui/wordset_toggle.tsx
+++ b/frontend/ui/wordset_toggle.tsx
@@ -12,7 +12,10 @@ const WordSetToggle = ({
   return (
     <div
       className={ selected ? "btn-wordsettoggle selected" : "btn-wordsettoggle"}
-      onClick={onToggle}>
+      onClick={onToggle}
+      role="checkbox"
+      aria-checked={!!selected}
+    >
       {label}
     </div>
   );


### PR DESCRIPTION
This pull request adds screen reader accessibility to the frontend UI. This is mainly achieved by adding "role" and various "aria-" attributes within the JSX elements in various .tsx files. These accessibility changes are based off of best practices suggested in [React's Accessibility Guide](https://reactjs.org/docs/accessibility.html). Note that the various "aria-" attributes use hyphen case instead of the typical camel case used in React since they are straight HTML, as discussed in React's guide.