### PR TITLE
cmd/codenames: add checkpoint bootstrapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20200730174046-fdd14bd4180c
 	github.com/jbowens/dictionary v0.0.0-20160629041621-229cf68df1a6
 	github.com/kr/pretty v0.1.0
+	github.com/pkg/errors v0.9.1
 	golang.org/x/sys v0.0.0-20200802091954-4b90ce9b60b3 // indirect
 )


### PR DESCRIPTION
Add facilities for bootstrapping a server from an existing server's
Pebble database. It does not guarantee that writes won't be lost, but it
should be enough for this project's requirements.