### PR TITLE
frontend: don't stop polling after an error (regression)

### DIFF
--- a/frontend/ui/game.tsx
+++ b/frontend/ui/game.tsx
@@ -148,20 +148,18 @@ export class Game extends React.Component {
         state_id: state_id,
       })
       .then(({ data }) => {
-        this.setState(
-          (oldState) => {
-            const stateToUpdate = { game: data };
-            if (oldState.game && data.created_at != oldState.game.created_at) {
-              stateToUpdate.codemaster = false;
-            }
-            return stateToUpdate;
-          },
-          () => {
-            setTimeout(() => {
-              this.refresh();
-            }, 2000);
+        this.setState((oldState) => {
+          const stateToUpdate = { game: data };
+          if (oldState.game && data.created_at != oldState.game.created_at) {
+            stateToUpdate.codemaster = false;
           }
-        );
+          return stateToUpdate;
+        });
+      })
+      .finally(() => {
+        setTimeout(() => {
+          this.refresh();
+        }, 2000);
       });
   }
 


### PR DESCRIPTION
commit 953537f6fdb4 ("Replace jquery w/ axios") / PR #126, which was supposed to be a straightforward port of existing functionality from one library to another, moved the logic that queues a new game state request from a jQuery `.complete()` callback, which runs regardless of whether the request succeeded or not, to a React `.setState()` completion callback, which only runs if the request succeeded (since that's the only case where `setState()` is called).

This appears to have been unintentional, and it has the effect of stopping state updates altogether after a single one fails, with the only recourse being to refresh the page. This is clearly a bad user experience, and me and my friends have personally experienced it frequently in every game we've played for the last few weeks.

Fix the problem by moving the logic into a `.finally()` callback, which will execute regardless of whether the request succeeded or failed.

I have not discovered why requests are failing in the first place. I can reliably reproduce a failed request on the https://horsepaste.com/ instance within five minutes with a single browser window, but I cannot reproduce it all on a local instance. The predominant failure mode is a prematurely closed connection, but I also observed a 500 error response once. Since I cannot reproduce it locally and a cursory code review of the server didn't turn up anything suspicious, I'm inclined to just attribute the failures to one or more of
- Brief Wi-Fi disconnections of my client devices
- Router / firewall congestion somewhere on the internet
- High network / CPU / memory load on your hosted instance

None of which we can really fix.

Edit: I take back what I said about reliably reproducing request failures within 5 minutes on https://horsepaste.com/. That was true while I was writing this patch, but I just went back and tried again (4 browser instances open to the same game) and have not yet had failure on any of them after about 20 minutes.